### PR TITLE
Change new tab url check for firefox

### DIFF
--- a/src/background/openInNewTab.js
+++ b/src/background/openInNewTab.js
@@ -1,6 +1,6 @@
 export const openInNewTab = tab => {
   // If it's a new tab, open directly in it
-  if (tab.url === 'chrome://newtab/') {
+  if (tab.url === 'chrome://newtab/' || tab.url === 'about:newtab') {
     return chrome.tabs.update(tab.id, {
       url: chrome.extension.getURL('index.html'),
     });


### PR DESCRIPTION
On firefox the new tab url is not `chrome://newtab/`, this change it with the correct one on firefox.

(Maybe you will want to do some lodash for that)