### PR TITLE
Add ellipsis and overflow to repo cards titles

### DIFF
--- a/src/components/RepoCard/RepoCard.scss
+++ b/src/components/RepoCard/RepoCard.scss
@@ -37,6 +37,8 @@
   &__Name {
     font-size: 24px;
     margin-bottom: 5px;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   &__Description {


### PR DESCRIPTION
Hi, here is quick fix for too long repo cards titles.