### PR TITLE
32/chrome-storage-instead-of-local-storage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "<version>",
   "short_name": "OctoLenses Browser Extension",
   "description": "Watch your repos and discover awesome things directly from your New Tab page.",
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "storage"],
   "background": {
     "scripts": ["background.js"]
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "prettier": "^1.14.2",
     "rimraf": "^2.6.2",
     "semver": "^5.5.0",
-    "tailwindcss": "^0.7.3"
+    "tailwindcss": "^0.7.3",
+    "typescript": "^3.3.3"
   },
   "scripts": {
     "clean": "rimraf dist/",

--- a/src/lib/storage/chromeStorage.ts
+++ b/src/lib/storage/chromeStorage.ts
@@ -1,0 +1,27 @@
+import { IStorage } from 'mobx-persist/lib/storage';
+
+export const chromeStorage: IStorage = {
+  getItem(key: string): Promise<string> {
+    return new Promise(resolve => {
+      chrome.storage.sync.get(key, result => {
+        resolve(result[key] || null);
+      });
+    });
+  },
+
+  removeItem(key: string): Promise<void> {
+    return new Promise(resolve => {
+      chrome.storage.sync.remove(key, () => {
+        resolve(null);
+      });
+    });
+  },
+
+  setItem(key: string, value: string): Promise<void> {
+    return new Promise(resolve => {
+      chrome.storage.sync.set({ [key]: value }, () => {
+        resolve(null);
+      });
+    });
+  },
+};

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,15 @@
+import { chromeStorage } from './chromeStorage';
+
+declare global {
+  const chrome: any;
+}
+
+export function getStorage() {
+  if (chrome.storage) {
+    console.info('Using chrome.storage API');
+    return chromeStorage;
+  }
+
+  console.info('Defaulting to localStorage');
+  return localStorage;
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,9 +5,13 @@ import { navigation } from './navigation';
 import { filters } from './filters';
 import { trends } from './trends';
 import { settings } from './settings';
+import { getStorage } from '../lib/storage';
 
 const hydrateStores = async () => {
-  const hydrate = create({});
+  const hydrate = create({
+    storage: getStorage(),
+  });
+
   await Promise.all([
     hydrate('navigationStore', navigation),
     hydrate('settingsStore', settings),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6705,6 +6705,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
+  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
+
 ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"


### PR DESCRIPTION
This make the extension use chromeStorage if available, defaulting to localStorage if not available.

This should allow synchronising OctoLenses settings between two different machines

----

### TODO:
- Proper `chromeStorage` error handling (cf. https://developer.chrome.com/apps/storage#property-sync)
- Migration strategy `localStorage -> chromeStorage` (I think it's acceptable to lose data here)