### PR TITLE
Add merged and unmerged values on status filter.

### DIFF
--- a/src/containers/IssueCard/IssueCard.js
+++ b/src/containers/IssueCard/IssueCard.js
@@ -8,7 +8,7 @@ import { LabelBadge } from '../../components/LabelBadge';
 
 import { ContextualDropdown } from './ContextualDropdown';
 
-const StatusIndicator = ({ status }) => {
+const CIStatusIndicator = ({ status }) => {
   if (!status) {
     return null;
   }
@@ -67,7 +67,7 @@ const _IssueCard = ({ issue, settings }) => {
               </a>
             </span>
 
-            <StatusIndicator status={issue.status} />
+            <CIStatusIndicator status={issue.status} />
           </div>
         </div>
         <div

--- a/src/containers/IssueCard/IssueCard.js
+++ b/src/containers/IssueCard/IssueCard.js
@@ -25,7 +25,7 @@ const IssueStatusIndicator = ({ type, state }) => (
   />
 );
 
-const CIStatusIndicator = ({ status }) => {
+const CheckStatusIndicator = ({ status }) => {
   if (!status) {
     return null;
   }
@@ -75,7 +75,7 @@ const _IssueCard = ({ issue, settings }) => {
               </a>
             </span>
 
-            <CIStatusIndicator status={issue.status} />
+            <CheckStatusIndicator status={issue.status} />
           </div>
         </div>
         <div

--- a/src/containers/IssueCard/IssueCard.js
+++ b/src/containers/IssueCard/IssueCard.js
@@ -8,6 +8,24 @@ import { LabelBadge } from '../../components/LabelBadge';
 
 import { ContextualDropdown } from './ContextualDropdown';
 
+const STATE_COLORS = {
+  OPEN: 'text-green',
+  CLOSED: 'text-red',
+  MERGED: 'text-purple',
+};
+
+const IssueStatusIndicator = ({ type, state }) => (
+  <i
+    className={cx(
+      'mr-2',
+      type === 'PullRequest'
+        ? 'fas fa-code-branch'
+        : 'fas fa-exclamation-circle',
+      STATE_COLORS[state]
+    )}
+  />
+);
+
 const CIStatusIndicator = ({ status }) => {
   if (!status) {
     return null;
@@ -20,9 +38,6 @@ const CIStatusIndicator = ({ status }) => {
 };
 
 const _IssueCard = ({ issue, settings }) => {
-  const isPR = issue.type === 'PullRequest';
-  const isOpen = issue.state === 'open';
-
   const linkStyle = settings.isDark
     ? 'text-blue-light'
     : 'text-blue hover:text-blue-dark';
@@ -42,13 +57,7 @@ const _IssueCard = ({ issue, settings }) => {
       <div className="min-w-0">
         <div className="flex items-start">
           <div className="flex-1 flex items-center mb-1 min-w-0">
-            <i
-              className={cx(
-                'mr-2',
-                isPR ? 'fas fa-code-branch' : 'fas fa-exclamation-circle',
-                isOpen ? 'text-green' : 'text-red'
-              )}
-            />
+            <IssueStatusIndicator type={issue.type} state={issue.state} />
 
             <span className={cx('truncate pb-1 min-w-0', linkStyle)}>
               <a

--- a/src/containers/IssueCard/IssueCard.js
+++ b/src/containers/IssueCard/IssueCard.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { chain } from 'lodash';
 import cx from 'classnames';
 import timeago from 'timeago.js';
 import { inject, observer } from 'mobx-react';
@@ -8,7 +7,7 @@ import { LabelBadge } from '../../components/LabelBadge';
 
 import { ContextualDropdown } from './ContextualDropdown';
 
-const STATE_COLORS = {
+const ISSUE_STATUS_COLORS = {
   OPEN: 'text-green',
   CLOSED: 'text-red',
   MERGED: 'text-purple',
@@ -21,7 +20,7 @@ const IssueStatusIndicator = ({ type, state }) => (
       type === 'PullRequest'
         ? 'fas fa-code-branch'
         : 'fas fa-exclamation-circle',
-      STATE_COLORS[state]
+      ISSUE_STATUS_COLORS[state]
     )}
   />
 );

--- a/src/lib/filters/index.js
+++ b/src/lib/filters/index.js
@@ -2,6 +2,7 @@ import { find, capitalize, sortBy } from 'lodash';
 
 import { type } from './type';
 import { status } from './status';
+import { mergeStatus } from './mergeStatus';
 import { review } from './review';
 
 const makeSimplePredicate = (name, { label, placeholder }) => ({
@@ -46,6 +47,7 @@ export const PREDICATES = sortBy(
     }),
     type,
     status,
+    mergeStatus,
     review,
   ],
   'label'

--- a/src/lib/filters/mergeStatus.js
+++ b/src/lib/filters/mergeStatus.js
@@ -1,0 +1,11 @@
+export const mergeStatus = {
+  name: 'merge status',
+  label: 'Merge Status',
+  type: 'dropdown',
+  choices: [
+    { value: 'merged', label: 'Merged' },
+    { value: 'unmerged', label: 'Unmerged' },
+  ],
+  negatable: false,
+  serialize: ({ value }) => `is:${value}`,
+};

--- a/src/lib/filters/status.js
+++ b/src/lib/filters/status.js
@@ -5,6 +5,8 @@ export const status = {
   choices: [
     { value: 'open', label: 'Open' },
     { value: 'closed', label: 'Closed' },
+    { value: 'merged', label: 'Merged' },
+    { value: 'unmerged', label: 'Unmerged' },
   ],
   negatable: false,
   serialize: ({ value }) => `is:${value}`,

--- a/src/lib/filters/status.js
+++ b/src/lib/filters/status.js
@@ -5,8 +5,6 @@ export const status = {
   choices: [
     { value: 'open', label: 'Open' },
     { value: 'closed', label: 'Closed' },
-    { value: 'merged', label: 'Merged' },
-    { value: 'unmerged', label: 'Unmerged' },
   ],
   negatable: false,
   serialize: ({ value }) => `is:${value}`,


### PR DESCRIPTION
## Description
This PR adds the `merged` and `unmerged` values with a new `merge status` predicates.

Merged PRs have now a purple icon following the GitHub chart.

I also renamed the `StatusIndicator` component to `CIStatusIndicator` to avoid any confusion with the new `IssueStatusIndicator` component.

## Screenshot
<img width="1213" alt="capture d ecran 2019-02-25 a 14 04 53" src="https://user-images.githubusercontent.com/11693661/53339329-5a5ad500-3906-11e9-8627-e4f4004f121b.png">
